### PR TITLE
Please add hpp files to `fixed_math_include_files`

### DIFF
--- a/fixed_lib/CMakeLists.txt
+++ b/fixed_lib/CMakeLists.txt
@@ -9,8 +9,9 @@ target_include_directories( fixed_math
   )
 target_sources( fixed_math PRIVATE src/fixed_math.cc )
 
-file(GLOB fixed_math_include_files 
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/fixedmath/*.h 
+file(GLOB fixed_math_include_files
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/fixedmath/*.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/fixedmath/*.hpp
   )
 
 file(GLOB fixed_math_include_files_detail 


### PR DESCRIPTION
When I try to install this library, I found `fixed_math.hpp` is not installed.
It seems to be caused by the lack of GLOB patterns.

This PR tries to solve it.