### PR TITLE
fix msvc compilation error

### DIFF
--- a/fixed_lib/include/fixedmath/fixed_math.hpp
+++ b/fixed_lib/include/fixedmath/fixed_math.hpp
@@ -63,7 +63,7 @@ namespace fixedmath
   constexpr fixed_t operator -( fixed_t l ) noexcept;
   
   ///\brief converts any floating point or integral value into fixed point
-  template<typename arithmethic_type>
+  template<typename arithmethic_type, typename>
   constexpr fixed_t arithmetic_to_fixed( arithmethic_type value ) noexcept;
   
   /// implicit convertion to double from fixed


### PR DESCRIPTION
I met a compilation error on Visual Studio 2019.
Error message is following:
```
fixed_math\math.h(40,5): error C2668: 'fixedmath::arithmetic_to_fixed': ambiguous call to overloaded function [msvc-192-x86_64-17-release\test_package.vcxproj]
fixed_math/fixed_math.hpp(67,21): message : could be 'fixedmath::fixed_t fixedmath::arithmetic_to_fixed<arithmethic_type>(arithmethic_type) noexcept' [msvc-192-x86_64-17-release\test_package.vcxproj]
          with
          [
              arithmethic_type=double
          ]
fixed_math\math.h(156,21): message : or       'fixedmath::fixed_t fixedmath::arithmetic_to_fixed<arithmethic_type,void>(arithmethic_type) noexcept' [test_package.vcxproj]
          with
          [
              arithmethic_type=double
          ]
fixed_math\math.h(40,5): message : while trying to match the argument list '(const arithmethic_type)' [test_package.vcxproj]
          with
          [
              arithmethic_type=double
          ]
test_package.cpp(20): message : see reference to function template instantiation 'fixedmath::fixed_t::fixed_t<double,void>(const arithmethic_type &) noexcept' being compiled [test_package.vcxproj]
          with
          [
              arithmethic_type=double
          ]
```

A mismatch in forward declarations seems to be the cause.

In fixed_math.hpp
```cpp
  template<typename arithmethic_type>
  constexpr fixed_t arithmetic_to_fixed( arithmethic_type value ) noexcept;
```

In math.hpp
```cpp
  template<typename arithmethic_type,
    typename = std::enable_if_t<detail::is_arithmetic_and_not_fixed_v<arithmethic_type>>
    >
  constexpr fixed_t arithmetic_to_fixed( arithmethic_type value ) noexcept;
```

This PR tries to fix it.
