### PR TITLE
Severe ERROR when installing fixed_lib

### DIFF
--- a/fixed_lib/CMakeLists.txt
+++ b/fixed_lib/CMakeLists.txt
@@ -23,10 +23,10 @@ install(TARGETS fixed_math
 )
 
 install(FILES ${fixed_math_include_files}
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fixed_math 
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fixedmath 
         )
 install(FILES ${fixed_math_include_files_detail}
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fixed_math/detail
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fixedmath/detail
         )
 
 set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/fixed_math)


### PR DESCRIPTION
When in Linux, try to install this lib like:

> git clone https://github.com/arturbac/fixed_math.git
> cd fixed_math
> cmake .
> cd fixed_lib
> make -install

It will finally install this lib at _/usr/local/include/fixed_math_ , not the correct dir _/usr/local/include/fixedmath_